### PR TITLE
Fix uninitialized `fused_shift_log_probas` in `forward()`

### DIFF
--- a/tranception/model_pytorch.py
+++ b/tranception/model_pytorch.py
@@ -783,6 +783,7 @@ class TranceptionLMHeadModel(GPT2PreTrainedModel):
         lm_logits = self.lm_head(hidden_states)
 
         loss = None
+        fused_shift_log_probas = None
         if labels is not None:
             # Shift so that tokens < n predict n
             shift_logits = lm_logits[..., :-1, :].contiguous()
@@ -845,7 +846,6 @@ class TranceptionLMHeadModel(GPT2PreTrainedModel):
             else:
                 loss_fct = CrossEntropyLoss()
                 loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
-                fused_shift_log_probas = None
 
         if not return_dict:
             output = (lm_logits,) + transformer_outputs[1:] 


### PR DESCRIPTION
When using [`model.generate()`](https://huggingface.co/docs/transformers/v4.24.0/en/main_classes/text_generation#transformers.generation_utils.GenerationMixin.generate), we were getting an error that `fused_shift_log_probas` was uninitialized when `labels` is `None`.

This PR ensures that `fused_shift_log_probas` is initialized as `None` regardless of the value of `labels`.

@hanspinner