### PR TITLE
Make Tranception pip installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,6 @@ from setuptools import setup
 
 setup(
     name="tranception",
-    version="0.0.1",
+    version="0.1.0",
     packages=["tranception", "tranception.utils"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,5 +4,5 @@ from setuptools import setup
 setup(
     name="tranception",
     version="0.0.1",
-    packages=['tranception'],
+    packages=["tranception", "tranception.utils"],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+from setuptools import setup
+
+
+setup(
+    name="tranception",
+    version="0.0.1",
+    packages=['tranception'],
+)

--- a/tranception/__init__.py
+++ b/tranception/__init__.py
@@ -1,1 +1,1 @@
-from tranception import config
+# from tranception import config

--- a/tranception/__init__.py
+++ b/tranception/__init__.py
@@ -1,1 +1,1 @@
-from tranception.utils import config
+from tranception import config

--- a/tranception/__init__.py
+++ b/tranception/__init__.py
@@ -1,1 +1,1 @@
-from . import config
+from tranception.utils import config

--- a/tranception/utils/__init__.py
+++ b/tranception/utils/__init__.py
@@ -1,1 +1,1 @@
-from . import scoring_utils, msa_utils
+from tranception.utils import scoring_utils, msa_utils

--- a/tranception/utils/__init__.py
+++ b/tranception/utils/__init__.py
@@ -1,1 +1,1 @@
-from tranception.utils import scoring_utils, msa_utils
+# from tranception.utils import scoring_utils, msa_utils

--- a/tranception/utils/scoring_utils.py
+++ b/tranception/utils/scoring_utils.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os
 import tqdm
 import re

--- a/tranception/utils/scoring_utils.py
+++ b/tranception/utils/scoring_utils.py
@@ -1,3 +1,4 @@
+from __future__ import absolute_import
 import os
 import tqdm
 import re

--- a/tranception/utils/scoring_utils.py
+++ b/tranception/utils/scoring_utils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+# from __future__ import absolute_import
 import os
 import tqdm
 import re


### PR DESCRIPTION
First of all, thank you for open sourcing Tranception.

It would be nice if Tranception were `pip` installable.

This pull requests makes a very minor change (adding a `setup.py` file) that makes it possible to pip install with `python -m pip install git+https://github.com/OATML-Markslab/Tranception`.